### PR TITLE
Changed ReadWriteOnce to ReadWriteMany to resolve immutable error

### DIFF
--- a/charts/webjive/templates/webjive-pv.yaml
+++ b/charts/webjive/templates/webjive-pv.yaml
@@ -14,7 +14,7 @@ spec:
   capacity:
     storage: 1Gi
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   hostPath:
     path: /data/webjive-{{ template "webjive.name" . }}-{{ .Release.Name }}/
 
@@ -33,7 +33,7 @@ metadata:
 spec:
   storageClassName: standard
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi


### PR DESCRIPTION
On a Mac using minikube (driver virtualbox)
```
minikube version
minikube version: v1.2.0

tiller -version
v2.14.1

helm version
Client: &version.Version{SemVer:"v2.14.1", GitCommit:"5270352a09c7e8b6e8c9593002a73535276507c0", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.14.1", GitCommit:"5270352a09c7e8b6e8c9593002a73535276507c0", GitTreeState:"clean"}
```
The following error occurred:

```
make deploy KUBE_NAMESPACE=integration HELM_CHART=webjive
Name:         integration
Labels:       <none>
Annotations:  <none>
Status:       Active

No resource quota.

No resource limits.
SSL cert already exits in charts/webjive/data ... skipping
secret/tls-secret-webjive-test created
ingress.extensions/webjive-tangogql-ing-webjive-test created
ingress.extensions/webjive-authserver-ing-webjive-test created
ingress.extensions/webjive-main-ing-webjive-test created
ingress.extensions/webjive-dashboard-ing-webjive-test created
persistentvolume/mongodb-webjive-test created
persistentvolumeclaim/mongodb-webjive-test created
persistentvolume/webjive-webjive-test created
persistentvolumeclaim/webjive-webjive-test created
persistentvolume/webjive-webjive-test configured
service/mongodb-webjive-test created
statefulset.apps/mongodb-webjive-test created
service/webjive-webjive-test created
statefulset.apps/webjive-webjive-test created
The PersistentVolumeClaim "webjive-webjive-test" is invalid: spec: Forbidden: is immutable after creation except resources.requests for bound claims
make: *** [deploy] Error 1
```

Changing ReadWriteOnce to ReadWriteMany resolved the issue.

