### PR TITLE
Change map_hash_bucket_size to 64

### DIFF
--- a/charts/webjive/templates/webjive.yaml
+++ b/charts/webjive/templates/webjive.yaml
@@ -76,6 +76,10 @@ spec:
       - name: webjive
         image: "{{ .Values.webjive.image.registry }}/{{ .Values.webjive.image.image }}:{{ .Values.webjive.image.tag }}"
         imagePullPolicy: {{ .Values.webjive.image.pullPolicy }}
+        command:
+          - /bin/sh
+          - -c
+          - "sed -i '/^http /a \\ \\ \\ \\ map_hash_bucket_size 64;' /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
         ports:
         - name: webjive-http
           containerPort: 80


### PR DESCRIPTION
Without this change, we see the following error in some deployments:

    2020/05/07 09:38:35 [emerg] 1#1: could not build map_hash, you should increase map_hash_bucket_size: 32
    nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32